### PR TITLE
Exponential backoff support and a fix to verify

### DIFF
--- a/pycrits/__init__.py
+++ b/pycrits/__init__.py
@@ -104,7 +104,7 @@ class pycrits(object):
 
     # Actually do the fetching.
     def _do_fetch(self, url, params={}):
-        resp = self.get_url(url, params=params, verify=self._verify)
+        resp = self.get_url(url, params=params, verify=self._verify, proxies=None)
         if resp.status_code != 200:
             raise pycritsFetchError("Response code: %s" % resp.status_code)
 

--- a/pycrits/__init__.py
+++ b/pycrits/__init__.py
@@ -44,6 +44,7 @@ class pycrits(object):
         self._username = username
         self._api_key = api_key
         self._verify = True
+        self._retries = 0
 
     @property
     def host(self):
@@ -74,15 +75,24 @@ class pycrits(object):
     def verify(self):
         return self._verify
 
+    # Verify can take True, Talse or path to .pem file (to verify the server's cert)
     @verify.setter
     def verify(self, value):
-        self._verify = bool(value)
+        self._verify = value
 
-    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=10)
+    @property
+    def retries(self):
+        return self._retries
+
+    @retries.setter
+    def retries(self, value):
+        self._retries = value
+
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=self._retries)
     def post_url(self, url, data, files, verify, proxies):
             return requests.post(url, data=data, files=files, verify=verify, proxies=proxies)
 
-    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=10)
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=self._retries)
     def get_url(self, url, params, verify, proxies):
             return requests.get(url, params=params, verify=verify, proxies=proxies)
 

--- a/pycrits/__init__.py
+++ b/pycrits/__init__.py
@@ -6,7 +6,7 @@ import requests
 import backoff
 
 from zipfile import ZipFile
-from StringIO import StringIO
+from io import BytesIO
 
 class pycritsFetchError(Exception):
     def __init__(self, message):
@@ -296,7 +296,7 @@ class pycrits(object):
         if resp.status_code != 200:
             raise pycritsFetchError("Response code: %s" % resp.status_code)
 
-        return StringIO(resp.content)
+        return BytesIO(resp.content)
 
     # If not a zip file (ie: "No files found") just return an empty list.
     def _unzip_file(self, file_):

--- a/pycrits/__init__.py
+++ b/pycrits/__init__.py
@@ -3,6 +3,7 @@ import json
 import zipfile
 import hashlib
 import requests
+import backoff
 
 from zipfile import ZipFile
 from StringIO import StringIO
@@ -77,12 +78,20 @@ class pycrits(object):
     def verify(self, value):
         self._verify = bool(value)
 
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=10)
+    def post_url(self, url, data, files, verify, proxies):
+            return requests.post(url, data=data, files=files, verify=verify, proxies=proxies)
+
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=10)
+    def get_url(self, url, params, verify, proxies):
+            return requests.get(url, params=params, verify=verify, proxies=proxies)
+
     # Used for posting.
     def _post(self, url, params={}, files=None):
         params['username'] = self._username
         params['api_key'] = self._api_key
         url = self._base_url + url
-        resp = requests.post(url, data=params, files=files, verify=self._verify)
+        resp = self.post_url(url, data=params, files=files, verify=self._verify, proxies=None)
         if resp.status_code != 200:
             raise pycritsFetchError("Response code: %s" % resp.status_code)
 
@@ -95,7 +104,7 @@ class pycrits(object):
 
     # Actually do the fetching.
     def _do_fetch(self, url, params={}):
-        resp = requests.get(url, params=params, verify=self._verify)
+        resp = self.get_url(url, params=params, verify=self._verify)
         if resp.status_code != 200:
             raise pycritsFetchError("Response code: %s" % resp.status_code)
 
@@ -283,7 +292,7 @@ class pycrits(object):
         if id_:
             url += id_ + '/'
 
-        resp = requests.get(url, params=params, verify=self._verify)
+        resp = self.get_url(url, params=params, verify=self._verify)
         if resp.status_code != 200:
             raise pycritsFetchError("Response code: %s" % resp.status_code)
 

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,5 @@ setup(
     url = "https://github.com/crits/pycrits",
     packages=['pycrits'],
     long_description="Python interface to the CRITs API.",
-    install_requires=['requests']
+    install_requires=['requests', 'backoff']
 )


### PR DESCRIPTION
-  Added an exponential backoff for the requests
- verify parameter in requests module can take True, False, or a path to the .pem for server certificate verification against the given cert (if it's not present in the cert store). Previously the assumption was that verify has to be a boolean value.
