### PR TITLE
Fix an issue with default value for a decorator

### DIFF
--- a/pycrits/__init__.py
+++ b/pycrits/__init__.py
@@ -44,7 +44,6 @@ class pycrits(object):
         self._username = username
         self._api_key = api_key
         self._verify = True
-        self._retries = 0
 
     @property
     def host(self):
@@ -88,11 +87,11 @@ class pycrits(object):
     def retries(self, value):
         self._retries = value
 
-    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=self._retries)
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=1)
     def post_url(self, url, data, files, verify, proxies):
             return requests.post(url, data=data, files=files, verify=verify, proxies=proxies)
 
-    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=self._retries)
+    @backoff.on_exception(backoff.expo, requests.exceptions.RequestException, max_tries=1)
     def get_url(self, url, params, verify, proxies):
             return requests.get(url, params=params, verify=verify, proxies=proxies)
 


### PR DESCRIPTION
Variables as defaults to a decorator don't seem to work, switching to a static value.
